### PR TITLE
Short to long path on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _testmain.go
 Makefile
 *.control
 *.h
+generate_windows/postgresExeExports.def

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.png?v=103)](https://opensource.org/licenses/mit-license.php)
 
 # plgo
-plgo is an tool for easily creating PostgreSQL extensions with stored procedures and triggers in golang. It creates wrapper code, PostgreSQL extension files and builds your package.
+Tool for easily creating PostgreSQL extensions with stored procedures and triggers in golang. It creates wrapper code, PostgreSQL extension files and builds your package.
 
 contribution of all kind welcome!
 

--- a/generate_windows/generate_postgresdef.ps1
+++ b/generate_windows/generate_postgresdef.ps1
@@ -1,0 +1,18 @@
+# Generates interface library file for postgres.exe. 
+# MSVC compiled file postgres.lib can't be used by gcc (gcc imports nothing from postgres.exe).
+# Use genereted libpostgresexe.lib when linking with postgres.exe. 
+# You need dlltool.exe in your path. Dlltool.exe is a part of gcc for mindows (mingw)
+# You need dumpbin.exe.
+
+$YourPathToPostgres = 'C:\Program Files\PostgreSQL\10.9-5.1C\'
+$YourPathToMSVCbin = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.14.26428\bin\'
+
+# creats 'exports definition file .def'
+'LIBRARY postgres.exe
+EXPORTS' | Out-File .\postgresExeExports.def -encoding utf8
+
+# // runs msvc's dumpbin.exe /exports to get exports of postgres.exe
+& $YourPathToMSVCbin'Hostx64\x64\dumpbin.exe' /exports $YourPathToPostgres'bin\postgres.exe' | Select-Object -Skip 19 | Select-Object -SkipLast 8 | foreach { echo $_.ToString().SubString(26)} | Out-File .\postgresExeExports.def -Append -encoding utf8
+
+# // generates 'interface library' from .def file to use with gcc mingw on Windows to link to postgres.exe
+dlltool.exe -d .\postgresExeExports.def -l libpostgresexe.lib -D postgres.exe $YourPathToPostgres'bin\postgres.exe'

--- a/generate_windows/generate_postgresdef.ps1
+++ b/generate_windows/generate_postgresdef.ps1
@@ -11,8 +11,10 @@ $YourPathToMSVCbin = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Commun
 'LIBRARY postgres.exe
 EXPORTS' | Out-File .\postgresExeExports.def -encoding utf8
 
+echo 'running dumpbin.exe /exports '$YourPathToPostgres'bin\postgres.exe'
 # // runs msvc's dumpbin.exe /exports to get exports of postgres.exe
 & $YourPathToMSVCbin'Hostx64\x64\dumpbin.exe' /exports $YourPathToPostgres'bin\postgres.exe' | Select-Object -Skip 19 | Select-Object -SkipLast 8 | foreach { echo $_.ToString().SubString(26)} | Out-File .\postgresExeExports.def -Append -encoding utf8
 
+echo 'running dlltool.exe -d .\postgresExeExports.def -l libpostgresInterfaceLib.a -D postgres.exe' $YourPathToPostgres'bin\postgres.exe'
 # // generates 'interface library' from .def file to use with gcc mingw on Windows to link to postgres.exe
-dlltool.exe -d .\postgresExeExports.def -l libpostgresexe.lib -D postgres.exe $YourPathToPostgres'bin\postgres.exe'
+dlltool.exe -d .\postgresExeExports.def -l libpostgresInterfaceLib.a -D postgres.exe $YourPathToPostgres'bin\postgres.exe'

--- a/pl.go
+++ b/pl.go
@@ -1,8 +1,11 @@
 package plgo
 
 /*
-#cgo CFLAGS: -I/usr/include/postgresql/server
+#cgo CFLAGS: -I"/usr/include/postgresql/server" -fpic
 #cgo LDFLAGS: -shared
+//{windowsCFLAGS}
+
+typedef unsigned int uint;
 
 #include "postgres.h"
 #include "fmgr.h"

--- a/plgo/modulewriter.go
+++ b/plgo/modulewriter.go
@@ -32,7 +32,15 @@ type ModuleWriter struct {
 //NewModuleWriter parses the go package and returns the FileSet and AST
 func NewModuleWriter(packagePath string) (*ModuleWriter, error) {
 	fset := token.NewFileSet()
-	f, err := parser.ParseDir(fset, packagePath, nil, parser.ParseComments)
+	//za+
+	filtertestfiles := func(fi os.FileInfo) bool {
+		if strings.HasSuffix(fi.Name(), "_test.go") {
+			return false
+		}
+		return true
+	}
+	//za+
+	f, err := parser.ParseDir(fset, packagePath, filtertestfiles, parser.ParseComments)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse package: %s", err)
 	}
@@ -128,7 +136,7 @@ func (mw *ModuleWriter) writeplgo(tempPackagePath string) error {
 	if err != nil {
 		return fmt.Errorf("Cannot run pg_config: %s", err)
 	}
-	plgoSource = strings.Replace(plgoSource, "/usr/include/postgresql/server", string(postgresIncludeDir), 1)
+	plgoSource = strings.Replace(plgoSource, "/usr/include/postgresql/server", getcorrectpath(string(postgresIncludeDir)), 1)
 	var funcdec string
 	for _, f := range mw.functions {
 		funcdec += f.FuncDec()

--- a/plgo/pathnames.go
+++ b/plgo/pathnames.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package main
+
+// getcorrectpath used on Windows, see file pathnames_windows.go
+func getcorrectpath(p string) string {
+	return p
+}
+
+// addOtherIncludesAndLDFLAGS used on Windows, see file pathnames_windows.go
+func addOtherIncludesAndLDFLAGS(plgoSource *string, postgresIncludeDir string) {
+	return
+}

--- a/plgo/pathnames_windows.go
+++ b/plgo/pathnames_windows.go
@@ -1,0 +1,70 @@
+// +build windows
+
+// also need to include
+// include\server\port\win32_msvc
+// include\server\port\win32
+// include\server
+// include
+
+package main
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// getcorrectpath works around 8.3 name returned by pg_config --includedir-server.
+func getcorrectpath(p string) string {
+	repl := p
+	if p[len(p)-2:] == "\r\n" {
+		repl = p[:len(p)-2]
+	}
+
+	ret, err := shortToLongPath(repl)
+	if err != nil {
+		panic("in getcorrectpath: " + err.Error() + "\"" + repl + "\"")
+	}
+	return ret
+}
+
+// shortToLongPath makes syscall to transform 8.3 filaname form to 'long' filename
+func shortToLongPath(short83path string) (string, error) {
+	ptrshort, err := windows.UTF16PtrFromString(short83path)
+	if err != nil {
+		return "", err
+	}
+	n := uint32(400) // "enough" space
+morechars:
+	b := make([]uint16, n)
+	n, err = windows.GetLongPathName(ptrshort, &b[0], uint32(len(b)))
+	if err != nil {
+		if n != 0 {
+			// here n is already set by kernel to right count of tchars
+			goto morechars
+		}
+		return "", err
+	}
+	return windows.UTF16ToString(b[:n]), nil
+}
+
+// addOtherIncludesAndLDFLAGS used on Windows.
+// adds to CFLAGS -I .../server/port/win32
+// adds minGw gcc peculiarities workarounds:
+// adds #cgo CFLAGS:  -DHAVE_LONG_LONG_INT_64 -I"{{postgresinclude}}/port/win32"
+// adds #cgo LDFLAGS: -L../ -L "{{postgresinclude}}/../../lib/"
+// adds #cgo LDFLAGS: -lpostgresInterfaceLib
+func addOtherIncludesAndLDFLAGS(plgoSource *string, postgresIncludeDir string) {
+	windowsCFLAGS := `
+#cgo CFLAGS:  -DHAVE_LONG_LONG_INT_64 -I"{{postgresinclude}}/port/win32"
+// our import(interface) library libpostgresInterfaceLib.a build by mingw's dlltool.exe is in -L../
+#cgo LDFLAGS: -L../ -L "{{postgresinclude}}/../../lib/"
+// import library postgres.lib build by msvc CAN'T be used by mingw gcc on windows, silent erronous usage.
+#cgo LDFLAGS: -lpostgresInterfaceLib  
+`
+	adds := strings.Replace(windowsCFLAGS, "{{postgresinclude}}", postgresIncludeDir, -1)
+
+	*plgoSource = strings.Replace(*plgoSource, "//{windowsCFLAGS}", adds, 1)
+
+	return
+}

--- a/plgo/pathnames_windows.go
+++ b/plgo/pathnames_windows.go
@@ -1,7 +1,6 @@
 // +build windows
 
 // also need to include
-// include\server\port\win32_msvc
 // include\server\port\win32
 // include\server
 // include
@@ -57,7 +56,7 @@ morechars:
 func addOtherIncludesAndLDFLAGS(plgoSource *string, postgresIncludeDir string) {
 	windowsCFLAGS := `
 #cgo CFLAGS:  -DHAVE_LONG_LONG_INT_64 -I"{{postgresinclude}}/port/win32"
-// our import(interface) library libpostgresInterfaceLib.a build by mingw's dlltool.exe is in -L../
+// our interface library libpostgresInterfaceLib.a build by mingw's dlltool.exe is in -L../
 #cgo LDFLAGS: -L../ -L "{{postgresinclude}}/../../lib/"
 // import library postgres.lib build by msvc CAN'T be used by mingw gcc on windows, silent erronous usage.
 #cgo LDFLAGS: -lpostgresInterfaceLib  

--- a/plgo/plgo.go
+++ b/plgo/plgo.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 func printUsage() {
@@ -17,12 +18,17 @@ func buildPackage(buildPath, packageName string) error {
 	if err := os.Setenv("CGO_LDFLAGS_ALLOW", "-shared"); err != nil {
 		return err
 	}
-	switchx := ""
+	switchx := "-v" // substitutor
 	if verbose {
 		switchx = "-x"
 	}
-	goBuild := exec.Command("go", "build", switchx, "-buildmode=c-shared",
-		"-o", filepath.Join("build", packageName+".so"),
+	fileExt := ".so"
+	if runtime.GOOS == "windows" {
+		fileExt = ".dll"
+	}
+	goBuild := exec.Command("go", "build", switchx,
+		"-buildmode=c-shared",
+		"-o", filepath.Join("build", packageName+fileExt),
 		filepath.Join(buildPath, "package.go"),
 		filepath.Join(buildPath, "methods.go"),
 		filepath.Join(buildPath, "pl.go"),

--- a/plgo/plgo.go
+++ b/plgo/plgo.go
@@ -9,14 +9,19 @@ import (
 )
 
 func printUsage() {
-	fmt.Println(`Usage: plgo [path/to/package]`)
+	fmt.Println(`Usage: plgo [-v] [path/to/package]`)
+	flag.PrintDefaults()
 }
 
 func buildPackage(buildPath, packageName string) error {
 	if err := os.Setenv("CGO_LDFLAGS_ALLOW", "-shared"); err != nil {
 		return err
 	}
-	goBuild := exec.Command("go", "build", "-buildmode=c-shared",
+	switchx := ""
+	if verbose {
+		switchx = "-x"
+	}
+	goBuild := exec.Command("go", "build", switchx, "-buildmode=c-shared",
 		"-o", filepath.Join("build", packageName+".so"),
 		filepath.Join(buildPath, "package.go"),
 		filepath.Join(buildPath, "methods.go"),
@@ -30,7 +35,10 @@ func buildPackage(buildPath, packageName string) error {
 	return nil
 }
 
+var verbose bool
+
 func main() {
+	flag.BoolVar(&verbose, "v", false, "be verbose, 'go build -x'")
 	flag.Parse()
 	packagePath := "."
 	if len(flag.Args()) == 1 {


### PR DESCRIPTION
Allows usage of package plgo under Windows.

Fixes incorrect usage of returned path from "pg_config --includedir-server" on Windows. 
Emphasis on inability to use binary interface library postgres.lib from Postgres binary distribution with gcc mingw on Windows.
Contents a script to generate proper interface library file for postgres.exe to use with gcc on Windows when you compile your extension to Postgres.
