### PR TITLE
Fix return line in Postgres path for module writer

### DIFF
--- a/plgo/pathnames.go
+++ b/plgo/pathnames.go
@@ -2,9 +2,12 @@
 
 package main
 
+import "strings"
+
 // getcorrectpath used on Windows, see file pathnames_windows.go
 func getcorrectpath(p string) string {
-	return p
+	ret := strings.TrimRight(p, "\n")
+	return ret
 }
 
 // addOtherIncludesAndLDFLAGS used on Windows, see file pathnames_windows.go


### PR DESCRIPTION
This update removes newline characters from the end of the include path used by the module writer.